### PR TITLE
Replace "hustle" with "business" across all products

### DIFF
--- a/checkout-chatgpt-prompts.html
+++ b/checkout-chatgpt-prompts.html
@@ -6,7 +6,7 @@
   <title>50 ChatGPT Prompts - ClickMint Checkout</title>
   
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Get instant access to 50 ChatGPT Prompts for Side Hustlers - Boost your productivity with ready-to-use prompts. Flash Sale: Only $6!" />
+  <meta name="description" content="Get instant access to 50 ChatGPT Prompts for Side Businesses - Boost your productivity with ready-to-use prompts. Flash Sale: Only $6!" />
   <meta name="robots" content="noindex, nofollow" />
   
   <!-- Favicon -->
@@ -247,7 +247,7 @@
       <h3>What You'll Get:</h3>
       <ul class="feature-list">
         <li>50 professionally crafted ChatGPT prompts</li>
-        <li>Prompts specifically for side hustlers</li>
+        <li>Prompts specifically for side business owners</li>
         <li>Content creation and marketing prompts</li>
         <li>Business strategy and planning prompts</li>
         <li>Customer research and analysis prompts</li>
@@ -284,7 +284,7 @@
     
     <div class="security-badges">
       <div class="security-badge">
-        <span>🔒</span>
+        <span>����</span>
         <span>Secure Checkout</span>
       </div>
       <div class="security-badge">
@@ -352,8 +352,8 @@
               price_data: {
                 currency: 'usd',
                 product_data: {
-                  name: '50 ChatGPT Prompts for Side Hustlers',
-                  description: 'Ready-to-use prompts for boosting your side hustle with AI',
+                  name: '50 ChatGPT Prompts for Side Businesses',
+                  description: 'Ready-to-use prompts for boosting your side business with AI',
                 },
                 unit_amount: 600, // $6.00 in cents
               },

--- a/index-es.html
+++ b/index-es.html
@@ -900,16 +900,16 @@
           <div class="product-badge">OFERTA PAQUETE</div>
           <img
             src="assets/products/AI Hustle Thumb.jpg"
-            alt="Bóveda Iniciador Negocio IA"
+            alt="Bóveda Iniciador de Negocios IA"
           />
           <div class="card-content">
             <div class="instant-badge">⚡ Descarga Instantánea</div>
-            <h3>Bóveda Iniciador Negocio IA</h3>
+            <h3>Bóveda Iniciador de Negocios IA</h3>
             <div class="pricing">
               <span class="price">$25</span>
             </div>
             <p>
-              Paquete de herramientas esenciales de negocio IA para impulsar tu viaje.
+              Paquete de herramientas esenciales de negocios IA para impulsar tu viaje.
             </p>
             <a class="btn" href="https://buy.stripe.com/dRmcN6aQdgCX9kheX94wM0n" target="_blank"
               >Obtener Paquete Ahora</a

--- a/index.html
+++ b/index.html
@@ -4,17 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>
-      ClickMint – AI, Health & Mindset Tools | Digital Products for AI Hustlers
+      ClickMint – AI, Health & Mindset Tools | Digital Products for AI Entrepreneurs
     </title>
 
     <!-- SEO Meta Tags -->
     <meta
       name="description"
-      content="Smart AI tools and digital products for AI hustlers, health hackers, and conscious creators. Download free AI hustles guide + premium tools for content creation, email copy, and automation."
+      content="Smart AI tools and digital products for AI entrepreneurs, health hackers, and conscious creators. Download free AI businesses guide + premium tools for content creation, email copy, and automation."
     />
     <meta
       name="keywords"
-      content="AI tools, digital products, AI hustles, ChatGPT prompts, content creation, email copy, faceless YouTube, TikTok automation, AI business"
+      content="AI tools, digital products, AI businesses, ChatGPT prompts, content creation, email copy, faceless YouTube, TikTok automation, AI business"
     />
     <meta name="author" content="ClickMint" />
     <meta name="robots" content="index, follow" />
@@ -26,7 +26,7 @@
     />
     <meta
       property="og:description"
-      content="Smart AI tools and digital products for AI hustlers, health hackers, and conscious creators. Get your free AI hustles guide now!"
+      content="Smart AI tools and digital products for AI entrepreneurs, health hackers, and conscious creators. Get your free AI businesses guide now!"
     />
     <meta
       property="og:image"
@@ -44,7 +44,7 @@
     />
     <meta
       name="twitter:description"
-      content="Smart AI tools and digital products for AI hustlers, health hackers, and conscious creators."
+      content="Smart AI tools and digital products for AI entrepreneurs, health hackers, and conscious creators."
     />
     <meta
       name="twitter:image"
@@ -645,7 +645,7 @@
         "@context": "https://schema.org",
         "@type": "Organization",
         "name": "ClickMint",
-        "description": "Smart AI tools and digital products for AI hustlers, health hackers, and conscious creators",
+        "description": "Smart AI tools and digital products for AI entrepreneurs, health hackers, and conscious creators",
         "url": "https://clickmintai.com",
         "logo": "https://clickmintai.com/assets/logo.png",
         "sameAs": ["https://clickmintai.gumroad.com"],
@@ -789,7 +789,7 @@
               <span class="price">$6</span>
               <span class="original-price">$12</span>
             </div>
-            <p>Track your side hustle income like a pro.</p>
+            <p>Track your side business income like a pro.</p>
             <a class="btn" href="https://buy.stripe.com/8x25kE2jH4Uf541aGT4wM08" target="_blank"
               >Get Instant Access</a
             >
@@ -900,16 +900,16 @@
           <div class="product-badge">BUNDLE DEAL</div>
           <img
             src="assets/products/AI Hustle Thumb.jpg"
-            alt="AI Hustle Starter Vault"
+            alt="AI Business Starter Vault"
           />
           <div class="card-content">
             <div class="instant-badge">⚡ Instant Download</div>
-            <h3>AI Hustle Starter Vault</h3>
+            <h3>AI Business Starter Vault</h3>
             <div class="pricing">
               <span class="price">$25</span>
             </div>
             <p>
-              Bundle of essential AI hustle tools to kickstart your journey.
+              Bundle of essential AI business tools to kickstart your journey.
             </p>
             <a class="btn" href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" target="_blank"
               >Get Bundle Now</a
@@ -1146,7 +1146,7 @@
             At ClickMint, we believe that artificial intelligence isn't just a
             tool—it's the great equalizer. Whether you're a health hacker
             optimizing your wellness journey, a conscious creator building
-            authentic content, or an AI hustler launching your next venture, we
+            authentic content, or an AI entrepreneur launching your next venture, we
             provide the practical tools and proven strategies to turn your
             vision into reality.
           </p>
@@ -1406,7 +1406,7 @@
       const freeDownloadBtn = document.querySelector("a[download]");
       if (freeDownloadBtn) {
         freeDownloadBtn.addEventListener("click", function () {
-          trackConversion("free_download", 0, "10 AI Hustles Free");
+          trackConversion("free_download", 0, "10 AI Businesses Free");
         });
       }
 
@@ -1477,7 +1477,7 @@
           const trustBar = document.createElement("div");
           trustBar.className = "ad-trust-bar";
           trustBar.innerHTML =
-            '<div class="ad-trust-text">Loved by 5,000+ AI Hustlers! ✓ Instant Download ✓ Lifetime Updates ✓ Email Support</div>';
+            '<div class="ad-trust-text">Loved by 5,000+ AI Entrepreneurs! ✓ Instant Download ✓ Lifetime Updates ✓ Email Support</div>';
           headerEl.parentNode.insertBefore(trustBar, headerEl.nextSibling);
         }
 

--- a/thank-you-ai-email-generator.html
+++ b/thank-you-ai-email-generator.html
@@ -122,8 +122,8 @@
           </div>
 
           <div class="upsell-item">
-            <img src="assets/products/AI Hustle Thumb.jpg" alt="AI Hustle Starter Vault" />
-            <h4>AI Hustle Starter Vault</h4>
+            <img src="assets/products/AI Hustle Thumb.jpg" alt="AI Business Starter Vault" />
+            <h4>AI Business Starter Vault</h4>
             <div class="price">$25</div>
             <a href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" class="btn-upsell" target="_blank">Save $5</a>
           </div>

--- a/thank-you-ai-freelancer-service-bundle.html
+++ b/thank-you-ai-freelancer-service-bundle.html
@@ -468,7 +468,7 @@
         <h2 class="upsell-title">Complete Your AI Toolkit</h2>
         <div class="upsell-grid">
           <div class="upsell-item">
-            <h4>AI Side Hustle Starter Vault</h4>
+            <h4>AI Side Business Starter Vault</h4>
             <p>
               Perfect starter bundle with Revenue Tracker, Content Calendar, and
               Digital Product Generator.
@@ -477,7 +477,7 @@
             <a
               href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" target="_blank"
               class="upsell-btn"
-              onclick="trackUpsell('AI Side Hustle Starter Vault')"
+              onclick="trackUpsell('AI Side Business Starter Vault')"
               >Get This Bundle</a
             >
           </div>

--- a/thank-you-ai-hustle-starter-vault-es.html
+++ b/thank-you-ai-hustle-starter-vault-es.html
@@ -57,8 +57,8 @@
           <div class="bundle-item">
             <h4>Rastreador de Ingresos Secundarios de IA</h4>
             <div class="bundle-item-links">
-              <a href="assets/products/AI Side Hustle Revenue Tracker - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('Revenue Tracker PDF')">📄 PDF</a>
-              <a href="https://clickmintai.notion.site/AI-Side-Hustle-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547" class="download-btn notion-btn" target="_blank" onclick="trackDownload('Revenue Tracker Notion')">📝 Notion</a>
+              <a href="assets/products/AI Side Business Revenue Tracker - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('Revenue Tracker PDF')">📄 PDF</a>
+              <a href="https://clickmintai.notion.site/AI-Side-Business-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547" class="download-btn notion-btn" target="_blank" onclick="trackDownload('Revenue Tracker Notion')">📝 Notion</a>
             </div>
             <p>Sistema profesional de seguimiento para monitorear y optimizar los flujos de ingresos de tu negocio secundario de IA.</p>
           </div>
@@ -98,8 +98,8 @@
         gtag("event", "file_download", { file_name: productName, link_url: event.target.href });
       }
 
-      gtag("event", "purchase", { transaction_id: "hustle_starter_vault_" + Date.now(), value: 25, currency: "USD", items: [{ item_id: "ai-hustle-starter-vault", item_name: "Bóveda de Iniciadores de Negocios Secundarios de IA", category: "Bundle", quantity: 1, price: 25 }] });
-      gtag("event", "conversion", { send_to: "AW-17260187801/-ZBTCIO66vAaEJmhpqZA", value: 25.0, currency: "USD", transaction_id: "hustle_starter_vault_" + Date.now() });
+      gtag("event", "purchase", { transaction_id: "business_starter_vault_" + Date.now(), value: 25, currency: "USD", items: [{ item_id: "ai-business-starter-vault", item_name: "Bóveda de Iniciadores de Negocios Secundarios de IA", category: "Bundle", quantity: 1, price: 25 }] });
+      gtag("event", "conversion", { send_to: "AW-17260187801/-ZBTCIO66vAaEJmhpqZA", value: 25.0, currency: "USD", transaction_id: "business_starter_vault_" + Date.now() });
     </script>
   </body>
 </html>

--- a/thank-you-ai-hustle-starter-vault.html
+++ b/thank-you-ai-hustle-starter-vault.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Thank You - AI Side Hustle Starter Vault | ClickMint</title>
+    <title>Thank You - AI Side Business Starter Vault | ClickMint</title>
     <meta name="robots" content="noindex" />
 
     <!-- Google Tag Manager -->
@@ -347,14 +347,14 @@
         <div class="success-icon">🎉</div>
         <h1 class="main-title">Thank You for Your Purchase!</h1>
         <p class="subtitle">
-          Your AI Side Hustle Starter Vault is ready for download
+          Your AI Side Business Starter Vault is ready for download
         </p>
 
         <div class="confirmation-details">
           <h3>Order Confirmation</h3>
           <div class="detail-row">
             <span class="detail-label">Product:</span>
-            <span class="detail-value">AI Side Hustle Starter Vault</span>
+            <span class="detail-value">AI Side Business Starter Vault</span>
           </div>
           <div class="detail-row">
             <span class="detail-label">Amount:</span>
@@ -381,7 +381,7 @@
             <h3 class="download-title">AI Side Revenue Tracker</h3>
             <div class="download-links">
               <a
-                href="assets/products/AI Side Hustle Revenue Tracker - Professional Guide.pdf"
+                href="assets/products/AI Side Business Revenue Tracker - Professional Guide.pdf"
                 class="download-btn"
                 target="_blank"
                 onclick="trackDownload('AI Side Revenue Tracker PDF')"
@@ -389,7 +389,7 @@
                 📄 Download PDF
               </a>
               <a
-                href="https://clickmintai.notion.site/AI-Side-Hustle-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547"
+                href="https://clickmintai.notion.site/AI-Side-Business-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547"
                 class="download-btn notion-btn"
                 target="_blank"
                 onclick="trackDownload('AI Side Revenue Tracker Notion')"
@@ -399,7 +399,7 @@
             </div>
           </div>
           <p class="download-description">
-            Professional tracking system to monitor all your AI side hustle
+            Professional tracking system to monitor all your AI side business
             income streams, track expenses, and optimize profitability with
             detailed analytics and reporting templates.
           </p>
@@ -517,7 +517,7 @@
 
       // Track page view and conversion
       gtag("event", "page_view", {
-        page_title: "Thank You - AI Side Hustle Starter Vault",
+        page_title: "Thank You - AI Side Business Starter Vault",
         page_location: window.location.href,
       });
 
@@ -528,8 +528,8 @@
         currency: "USD",
         items: [
           {
-            item_id: "ai-hustle-starter-vault",
-            item_name: "AI Side Hustle Starter Vault",
+            item_id: "ai-business-starter-vault",
+            item_name: "AI Side Business Starter Vault",
             category: "Bundle",
             quantity: 1,
             price: 25,

--- a/thank-you-ai-office-powerpack.html
+++ b/thank-you-ai-office-powerpack.html
@@ -351,9 +351,9 @@
           <div class="upsell-product">
             <img
               src="assets/products/AI Hustle Thumb.jpg"
-              alt="AI Side Hustle Starter Vault"
+              alt="AI Side Business Starter Vault"
             />
-            <h4>AI Side Hustle Starter Vault</h4>
+            <h4>AI Side Business Starter Vault</h4>
             <div class="price">$25</div>
             <a href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" class="upsell-btn" target="_blank"
               >Save $10</a

--- a/thank-you-ai-revenue-tracker.html
+++ b/thank-you-ai-revenue-tracker.html
@@ -242,7 +242,7 @@
         <h2 class="download-title">📥 Access Your Revenue Tracker</h2>
                 <div class="download-buttons">
           <a
-            href="assets/products/AI Side Hustle Revenue Tracker - Professional Guide.pdf"
+            href="assets/products/AI Side Business Revenue Tracker - Professional Guide.pdf"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('PDF')"
@@ -250,7 +250,7 @@
             📄 Download PDF Guide
           </a>
           <a
-            href="https://www.notion.so/AI-Side-Hustle-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547?source=copy_link"
+            href="https://www.notion.so/AI-Side-Business-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547?source=copy_link"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('Notion')"
@@ -307,9 +307,9 @@
           <div class="upsell-product">
             <img
               src="assets/products/AI Hustle Thumb.jpg"
-              alt="AI Hustle Starter Vault"
+              alt="AI Business Starter Vault"
             />
-            <h4>AI Hustle Starter Vault</h4>
+            <h4>AI Business Starter Vault</h4>
             <div class="price">$15</div>
             <a href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" class="upsell-btn" target="_blank"
               >Save $5</a

--- a/thank-you-chatgpt-prompts-es.html
+++ b/thank-you-chatgpt-prompts-es.html
@@ -241,7 +241,7 @@
         <h2 class="download-title">🤖 Accede a tus Prompts de ChatGPT</h2>
         <div class="download-buttons">
           <a
-            href="assets/products/50 ChatGPT Prompts for Side Hustlers - Professional Guide.pdf"
+            href="assets/products/50 ChatGPT Prompts for Side Businesses - Professional Guide.pdf"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('PDF')"
@@ -249,7 +249,7 @@
             📄 Descargar Guía PDF
           </a>
           <a
-            href="https://clickmintai.notion.site/50-ChatGPT-Prompts-for-Side-Hustlers-21bd9e2eb3a9806d803cdb9dd99eeba7"
+            href="https://clickmintai.notion.site/50-ChatGPT-Prompts-for-Side-Businesses-21bd9e2eb3a9806d803cdb9dd99eeba7"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('Notion')"

--- a/thank-you-chatgpt-prompts.html
+++ b/thank-you-chatgpt-prompts.html
@@ -242,7 +242,7 @@
         <h2 class="download-title">📥 Access Your ChatGPT Prompts</h2>
                 <div class="download-buttons">
           <a
-            href="assets/products/50 ChatGPT Prompts for Side Hustlers - Professional Guide.pdf"
+            href="assets/products/50 ChatGPT Prompts for Side Businesses - Professional Guide.pdf"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('PDF')"
@@ -250,7 +250,7 @@
             📄 Download PDF Guide
           </a>
           <a
-            href="https://www.notion.so/50-ChatGPT-Prompts-for-Side-Hustlers-21bd9e2eb3a9806d803cdb9dd99eeba7?source=copy_link"
+            href="https://www.notion.so/50-ChatGPT-Prompts-for-Side-Businesses-21bd9e2eb3a9806d803cdb9dd99eeba7?source=copy_link"
             class="download-btn"
             target="_blank"
             onclick="trackDownload('Notion')"
@@ -307,9 +307,9 @@
           <div class="upsell-product">
             <img
               src="assets/products/AI Hustle Thumb.jpg"
-              alt="AI Hustle Starter Vault"
+              alt="AI Business Starter Vault"
             />
-            <h4>AI Hustle Starter Vault</h4>
+            <h4>AI Business Starter Vault</h4>
             <div class="price">$25</div>
             <a href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" class="upsell-btn" target="_blank"
               >Save $10</a

--- a/thank-you-content-calendar.html
+++ b/thank-you-content-calendar.html
@@ -307,9 +307,9 @@
           <div class="upsell-product">
             <img
               src="assets/products/AI Hustle Thumb.jpg"
-              alt="AI Hustle Starter Vault"
+              alt="AI Business Starter Vault"
             />
-            <h4>AI Hustle Starter Vault</h4>
+            <h4>AI Business Starter Vault</h4>
             <div class="price">$15</div>
             <a href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" class="upsell-btn" target="_blank"
               >Save $5</a

--- a/thank-you-faceless-creator-kit.html
+++ b/thank-you-faceless-creator-kit.html
@@ -466,7 +466,7 @@
         <h2 class="upsell-title">Complete Your AI Toolkit</h2>
         <div class="upsell-grid">
           <div class="upsell-item">
-            <h4>AI Side Hustle Starter Vault</h4>
+            <h4>AI Side Business Starter Vault</h4>
             <p>
               Perfect starter bundle with Revenue Tracker, Content Calendar, and
               Digital Product Generator.
@@ -475,7 +475,7 @@
             <a
               href="https://buy.stripe.com/dRmfZie2p1I37c93er4wM0m" target="_blank"
               class="upsell-btn"
-              onclick="trackUpsell('AI Side Hustle Starter Vault')"
+              onclick="trackUpsell('AI Side Business Starter Vault')"
               >Get This Bundle</a
             >
           </div>

--- a/thank-you-the-vault-all-access-es.html
+++ b/thank-you-the-vault-all-access-es.html
@@ -133,8 +133,8 @@
             <div class="download-header">
               <h3 class="download-title">Rastreador de Ingresos Secundarios de IA</h3>
               <div class="download-links">
-                <a href="assets/products/AI Side Hustle Revenue Tracker - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('AI Side Revenue Tracker PDF')">📄 PDF</a>
-                <a href="https://clickmintai.notion.site/AI-Side-Hustle-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547" class="download-btn notion-btn" target="_blank" onclick="trackDownload('AI Side Revenue Tracker Notion')">📝 Notion</a>
+                <a href="assets/products/AI Side Business Revenue Tracker - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('AI Side Revenue Tracker PDF')">📄 PDF</a>
+                <a href="https://clickmintai.notion.site/AI-Side-Business-Revenue-Tracker-223d9e2eb3a980739b2be679b4d11547" class="download-btn notion-btn" target="_blank" onclick="trackDownload('AI Side Revenue Tracker Notion')">📝 Notion</a>
               </div>
             </div>
             <p class="download-description">Sistema profesional de seguimiento para monitorear y optimizar todos los flujos de ingresos de tu negocio secundario de IA.</p>
@@ -144,8 +144,8 @@
             <div class="download-header">
               <h3 class="download-title">50 Prompts de ChatGPT</h3>
               <div class="download-links">
-                <a href="assets/products/50 ChatGPT Prompts for Side Hustlers - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('50 ChatGPT Prompts PDF')">📄 PDF</a>
-                <a href="https://clickmintai.notion.site/50-ChatGPT-Prompts-for-Side-Hustlers-21bd9e2eb3a9806d803cdb9dd99eeba7" class="download-btn notion-btn" target="_blank" onclick="trackDownload('50 ChatGPT Prompts Notion')">📝 Notion</a>
+                <a href="assets/products/50 ChatGPT Prompts for Side Businesses - Professional Guide.pdf" class="download-btn" target="_blank" onclick="trackDownload('50 ChatGPT Prompts PDF')">📄 PDF</a>
+                <a href="https://clickmintai.notion.site/50-ChatGPT-Prompts-for-Side-Businesses-21bd9e2eb3a9806d803cdb9dd99eeba7" class="download-btn notion-btn" target="_blank" onclick="trackDownload('50 ChatGPT Prompts Notion')">📝 Notion</a>
               </div>
             </div>
             <p class="download-description">Prompts listos para usar de ChatGPT diseñados específicamente para emprendedores de negocios secundarios.</p>


### PR DESCRIPTION
## Purpose
Remove the word "hustle" from all product names and descriptions as requested by the user, who felt it sounded gimmicky and wanted more professional terminology.

## Code changes
- Updated product names from "Side Hustlers" to "Side Businesses" and "AI Hustlers" to "AI Entrepreneurs"
- Changed "AI Hustle Starter Vault" to "AI Business Starter Vault" across all pages
- Modified meta descriptions, product titles, and marketing copy to use "business" instead of "hustle"
- Updated file references and links to reflect new naming convention
- Applied changes consistently across English and Spanish versions of the site
- Updated Stripe product data and tracking references to match new terminologyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7756dfca4a1543fd9ef71f50b323ef73/neon-works)

👀 [Preview Link](https://7756dfca4a1543fd9ef71f50b323ef73-neon-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7756dfca4a1543fd9ef71f50b323ef73</projectId>-->
<!--<branchName>neon-works</branchName>-->