### PR TITLE
Update Vault Stripe link to one-time fee

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -891,7 +891,7 @@
             </p>
             <a
               class="btn ultimate-btn"
-              href="https://buy.stripe.com/6oUeVe5vTgCXdAx4iv4wM0r" target="_blank"
+              href="https://buy.stripe.com/fZudRaaQdfyT2VT02f4wM0s" target="_blank"
               >Obtener Todo Ahora</a
             >
           </div>

--- a/index.html
+++ b/index.html
@@ -991,7 +991,7 @@
           <p class="collection-description" style="font-size: 1em; margin-bottom: 24px;">
             Get instant access to all 10 premium AI tools in one package.
           </p>
-          <a href="https://buy.stripe.com/6oUeVe0bzaezcwt16j4wM0q" class="btn-primary" target="_blank" style="padding: 12px 32px; font-size: 1em;">View Complete Collection</a>
+          <a href="https://buy.stripe.com/fZudRaaQdfyT2VT02f4wM0s" class="btn-primary" target="_blank" style="padding: 12px 32px; font-size: 1em;">View Complete Collection</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Summary
Updates the Stripe payment link for "The Vault" access to reflect the correct pricing model.

### Problem
The previous Stripe link for "The Vault" was configured as a monthly subscription charge, whereas the intended pricing model is a one-time fee.

### Solution
Replaced the existing Stripe checkout URLs with the new link provided for the one-time fee structure.

### Key Changes
- Updated the Stripe payment URL in `index.html` for "The Vault: All-Access".
- Updated the Stripe payment URL in `index-es.html` for "La Bóveda - Pase de Acceso Total".

---

<a href="https://builder.io/app/projects/7756dfca4a1543fd9ef71f50b323ef73/warm-enigma-sdpcjuc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://7756dfca4a1543fd9ef71f50b323ef73-warm-enigma-sdpcjuc1_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7756dfca4a1543fd9ef71f50b323ef73</projectId>-->
<!--<branchName>warm-enigma-sdpcjuc1</branchName>-->